### PR TITLE
hotfix/player-movement-drift

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -167,8 +167,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c5cef2c0e05e0844d910fa7f156abd23, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _speed: 10
-  _maxSpeed: 3
+  _speed: 50
+  _maxSpeed: 25
 --- !u!114 &807764299014293325
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Framework/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Framework/Gameplay/Player/PlayerMovement.cs
@@ -48,12 +48,7 @@ namespace DerailedDeliveries.Framework.Gameplay.Player
         {
             Vector3 newForce = new Vector3(_playerInput.x, 0, _playerInput.y) * _speed;
 
-            newForce += _rigidbody.velocity;
-
-            newForce.x = Mathf.Clamp(newForce.x, _maxSpeed * -1, _maxSpeed);
-            newForce.z = Mathf.Clamp(newForce.z, _maxSpeed * -1, _maxSpeed);
-
-            _rigidbody.velocity = newForce;
+            _rigidbody.AddForce(Vector3.ClampMagnitude(newForce, _maxSpeed));
         }
     }
 }


### PR DESCRIPTION
A hotfix to avoid the player drifting when not going exactly on 1 axis.